### PR TITLE
SDK fixes

### DIFF
--- a/DuoGamerSDK.m
+++ b/DuoGamerSDK.m
@@ -184,8 +184,8 @@ static inline BOOL isBitSet(int data, int bit){
         uint8_t buttons_2      = data[4];
         state.buttonA          = isBitSet(buttons_1, 0);
         state.buttonB          = isBitSet(buttons_1, 1);
-        state.buttonY          = isBitSet(buttons_1, 2);
-        state.buttonX          = isBitSet(buttons_1, 3);
+        state.buttonX          = isBitSet(buttons_1, 2);
+        state.buttonY          = isBitSet(buttons_1, 3);
         state.analogLeftClick  = isBitSet(buttons_1, 5);
         state.analogRightClick = isBitSet(buttons_1, 6);
         state.shoulderRight    = isBitSet(buttons_2,  0);

--- a/DuoGamerSDK.m
+++ b/DuoGamerSDK.m
@@ -167,11 +167,10 @@ static inline BOOL isBitSet(int data, int bit){
     self.accessory = nil;
 }
 
--(void)processPacket{
-    uint8_t * data = malloc(sizeof(uint8_t));
-    
+-(void)processPacket{    
     // moving analog joystick may send more packets than usual
     while ([readData length] >= SINGLE_PACKET_SIZE) {
+        uint8_t data[SINGLE_PACKET_SIZE];
         // valid fixed data, but ignore xor checksum
         [readData getBytes:(void *)data range:NSMakeRange(0, SINGLE_PACKET_SIZE)];
         if (data[0] != 0x5a) return;
@@ -204,8 +203,6 @@ static inline BOOL isBitSet(int data, int bit){
         
         [readData replaceBytesInRange:NSMakeRange(0, SINGLE_PACKET_SIZE) withBytes:NULL length:0];
     }
-    
-    free(data);
 }
 
 // asynchronous NSStream handleEvent method


### PR DESCRIPTION
This PR should fixes:

- On iOS 6 or higher, if no output stream is configured, input stream will receive nothing. _Ref_: [EADemo](https://developer.apple.com/library/content/samplecode/EADemo/Introduction/Intro.html)
- X/Y button should be inverted, at least on my joystick, the test result is inverted. 